### PR TITLE
Updated MCP calculator examples with correct mvn command

### DIFF
--- a/04-PracticalSamples/mcp/calculator/README.md
+++ b/04-PracticalSamples/mcp/calculator/README.md
@@ -262,7 +262,7 @@ Started McpServerApplication in X.XXX seconds
 
 In a new terminal:
 ```bash
-mvn test-compile exec:java -Dexec.mainClass="com.microsoft.mcp.sample.client.SDKClient"
+mvn test-compile exec:java -Dexec.mainClass="com.microsoft.mcp.sample.client.SDKClient" -Dexec.classpathScope=test
 ```
 
 You'll see output like:
@@ -275,7 +275,7 @@ Square Root Result = √16.00 = 4.00
 ### Step 3: Test with AI Client
 
 ```bash
-mvn test-compile exec:java -Dexec.mainClass="com.microsoft.mcp.sample.client.LangChain4jClient"
+mvn test-compile exec:java -Dexec.mainClass="com.microsoft.mcp.sample.client.LangChain4jClient" -Dexec.classpathScope=test
 ```
 
 You'll see the AI automatically using tools:


### PR DESCRIPTION
This pull request updates the `04-PracticalSamples/mcp/calculator/README.md` file to include a more specific classpath scope during the execution of Maven commands. This ensures that the test classpath is explicitly used when running the sample clients.

### Documentation updates:

* Updated the Maven command for running `SDKClient` to include `-Dexec.classpathScope=test`, ensuring the test classpath is used. (`[04-PracticalSamples/mcp/calculator/README.mdL265-R265](diffhunk://#diff-5b5bcfada1d9315bafccbe0eb87ce025e31502e38598659999521f17b3e8c515L265-R265)`)
* Updated the Maven command for running `LangChain4jClient` to include `-Dexec.classpathScope=test`, ensuring the test classpath is used. (`[04-PracticalSamples/mcp/calculator/README.mdL278-R278](diffhunk://#diff-5b5bcfada1d9315bafccbe0eb87ce025e31502e38598659999521f17b3e8c515L278-R278)`)# Purpose


