### PR TITLE
Fix link formatting in Japanese README

### DIFF
--- a/translations/ja/04-PracticalSamples/README.md
+++ b/translations/ja/04-PracticalSamples/README.md
@@ -59,7 +59,7 @@ CO_OP_TRANSLATOR_METADATA:
 
 ## 次のステップ
 
-[第5章: 責任ある生成型AI](../05-ResponsibleGenAI/README.md)
+[第5章: 責任ある生成AI](../05-ResponsibleGenAI/README.md)
 
 **免責事項**:  
 この文書は、AI翻訳サービス [Co-op Translator](https://github.com/Azure/co-op-translator) を使用して翻訳されています。正確性を追求しておりますが、自動翻訳には誤りや不正確な部分が含まれる可能性があります。元の言語で記載された文書が正式な情報源と見なされるべきです。重要な情報については、専門の人間による翻訳を推奨します。この翻訳の使用に起因する誤解や誤訳について、当社は一切の責任を負いません。


### PR DESCRIPTION
# Purpose

Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?

https://github.com/microsoft/Generative-AI-for-beginners-java/blob/main/translations/ja/04-PracticalSamples/README.md 

<img width="538" height="142" alt="image" src="https://github.com/user-attachments/assets/ee7cca30-6d5b-4eca-a470-18c7e14401b7" />

#PingMSFTDocs

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[ ] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
