### PR TITLE
Update token permission instructions in SetupDevEnvironment README

### DIFF
--- a/02-SetupDevEnvironment/README.md
+++ b/02-SetupDevEnvironment/README.md
@@ -224,7 +224,7 @@ Having issues? Here are common problems and solutions:
 - **Token not working?** 
   - Ensure you copied the entire token without any extra spaces
   - Verify the token is set correctly as an environment variable
-  - Check that your token has the correct permissions (Models: Read and write)
+  - Check that your token has the correct permissions (Models: Read-only)
 
 - **Maven not found?** 
   - If using dev containers/Codespaces, Maven should be pre-installed


### PR DESCRIPTION
# Purpose

This PR updates the token permission guidance in `02-SetupDevEnvironment/README.md` to resolve an inconsistency in the documentation.

Previously, the Troubleshooting section suggested `Models: Read and write`, while the setup steps instruct `Models: Read-only`. Since this example only performs inference calls to GitHub Models, **Read-only is sufficient**.

In addition, this repository previously had an issue where some translated versions of this file were missing (see: https://github.com/Azure/co-op-translator/issues/292). We have now addressed the root cause of that translation-missing issue, so it should not happen again. Once this change is merged, the translated copies will be regenerated and updated accordingly.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
